### PR TITLE
Change getProductById in ProductRepo to return an optional of a produ…

### DIFF
--- a/src/main/java/ProductDoesNotExistException.java
+++ b/src/main/java/ProductDoesNotExistException.java
@@ -1,0 +1,5 @@
+public class ProductDoesNotExistException extends RuntimeException {
+    public ProductDoesNotExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ProductRepo.java
+++ b/src/main/java/ProductRepo.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class ProductRepo {
     private List<Product> products;
@@ -13,13 +14,10 @@ public class ProductRepo {
         return products;
     }
 
-    public Product getProductById(String id) {
-        for (Product product : products) {
-            if (product.id().equals(id)) {
-                return product;
-            }
-        }
-        return null;
+    public Optional<Product> getProductById(String id) {
+        return products.stream()
+                .filter(p -> p.id().equals(id))
+                .findFirst();
     }
 
     public Product addProduct(Product newProduct) {

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -10,7 +10,7 @@ public class ShopService {
     public Order addOrder(List<String> productIds) throws ProductDoesNotExistException {
         List<Product> products = new ArrayList<>();
         for (String productId : productIds) {
-            if(!productRepo.getProductById(productId).isPresent()) {
+            if(productRepo.getProductById(productId).isEmpty()) {
                 throw new ProductDoesNotExistException("Product mit der Id: " + productId + " existiert nicht und konnte nicht bestellt werden!");
             }
             Product productToOrder = productRepo.getProductById(productId).get();

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -1,24 +1,30 @@
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class ShopService {
     private ProductRepo productRepo = new ProductRepo();
     private OrderRepo orderRepo = new OrderMapRepo();
 
-    public Order addOrder(List<String> productIds) {
+    public Order addOrder(List<String> productIds) throws ProductDoesNotExistException {
         List<Product> products = new ArrayList<>();
         for (String productId : productIds) {
-            Product productToOrder = productRepo.getProductById(productId);
-            if (productToOrder == null) {
-                System.out.println("Product mit der Id: " + productId + " konnte nicht bestellt werden!");
-                return null;
+            if(!productRepo.getProductById(productId).isPresent()) {
+                throw new ProductDoesNotExistException("Product mit der Id: " + productId + " existiert nicht und konnte nicht bestellt werden!");
             }
+            Product productToOrder = productRepo.getProductById(productId).get();
             products.add(productToOrder);
         }
 
         Order newOrder = new Order(UUID.randomUUID().toString(), products);
 
         return orderRepo.addOrder(newOrder);
+    }
+
+    public List<Order> getOrderByStatus(OrderStatus status) {
+        return orderRepo.getOrders().stream()
+                .filter(order -> order.status() == status)
+                .toList();
     }
 }

--- a/src/test/java/ProductRepoTest.java
+++ b/src/test/java/ProductRepoTest.java
@@ -27,7 +27,7 @@ class ProductRepoTest {
         ProductRepo repo = new ProductRepo();
 
         //WHEN
-        Product actual = repo.getProductById("1");
+        Product actual = repo.getProductById("1").get();
 
         //THEN
         Product expected = new Product("1", "Apfel");
@@ -46,7 +46,7 @@ class ProductRepoTest {
         //THEN
         Product expected = new Product("2", "Banane");
         assertEquals(actual, expected);
-        assertEquals(repo.getProductById("2"), expected);
+        assertEquals(repo.getProductById("2").get(), expected);
     }
 
     @org.junit.jupiter.api.Test


### PR DESCRIPTION
Change getProductById in ProductRepo to return an optional of a product or an empty one if the product does not exist
Create a ProductDoesNotExistException to reflect what kind of problem occured, namely the product not existing
Change addOrder in ShopService to incorporate the Optinal<Product> from getProductById and throw a ProductDoesNotExistException if the Optional is empty
Fix test in ProductRepoTest to handle the change to Optional<Product> instead of just a Product when testing with getProductById